### PR TITLE
Try reconnecting api for bad signature errors

### DIFF
--- a/src/chain_service/api.ts
+++ b/src/chain_service/api.ts
@@ -50,7 +50,9 @@ class ApiManager {
 
     try {
         return await apiCall(apiInstance.api);
-    } catch (initialError) {
+    } catch (initialError: any) {
+      // Only retry if the error is regarding bad signature error
+      if (initialError.name === "RpcError" && initialError.message.includes("Transaction has a bad signature")){
         console.log(`Error encountered, attempting to refresh the api...`);
         try {
             apiInstance = await this.connectApi(this.config.getNetwork().wss); 
@@ -59,6 +61,10 @@ class ApiManager {
         } catch (retryError) {
             throw retryError;
         }
+
+      }else{
+        throw initialError;
+      }
     }
   }
 }

--- a/src/chain_service/api.ts
+++ b/src/chain_service/api.ts
@@ -38,14 +38,14 @@ class ApiManager {
     console.log(`Connected to node ${network.wss}`);
   }
 
-  async getApi(): Promise<API> {
+  public async getApi(): Promise<API> {
     if (!this.apiInstanceDict["network"]) {
       await this.populateApis();
     }
     return this.apiInstanceDict["network"];
   }
 
-  public async executeApiCall(apiCall: (apiCall: any) => Promise<any>): Promise<any> {
+  public async executeApiCall(apiCall: (apiCall: ApiPromise) => Promise<any>): Promise<any> {
     let apiInstance = await this.getApi();
 
     try {

--- a/src/chain_service/faucet.ts
+++ b/src/chain_service/faucet.ts
@@ -200,7 +200,7 @@ export default class Faucet {
         this.registerLackOfFundsEvent();
     }else{
         console.log(
-          "\x1b[31m%s\x1b[0m",
+          "\x1b[31m",
           "🚫 Encountered some other error: ",
           error?.toString(),
           JSON.stringify(error),

--- a/src/chain_service/faucet.ts
+++ b/src/chain_service/faucet.ts
@@ -154,7 +154,7 @@ export default class Faucet {
 
   private async handleDispatchError(dispatchError: any) {
     if (dispatchError?.isModule) {
-      const decoded = await this.apiManager.executeApiCall(async (api) => api.registry.findMetaError(dispatchError.asModule));
+      const decoded =  (await this.apiManager.getApi()).api.registry.findMetaError(dispatchError.asModule);
       const { docs, name, section, method } = decoded;
 
       console.log(

--- a/src/chain_service/faucetErrors.ts
+++ b/src/chain_service/faucetErrors.ts
@@ -67,6 +67,42 @@ export class NoFundsError extends FaucetError {
   }
 }
 
+export class RpcSinkError extends FaucetError {
+  config: Config;
+  constructor(message: string, config: Config) {
+    super(message);
+    this.config = config;
+    this.name = "Other RPC Error";
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+
+  serializeForSlack(): SlackBlockkitMessage {
+    let context = this.appendContext(this.config.getNetwork());
+
+    let errorBlock: SlackBlock = {
+      type: "section",
+      fields: [
+        {
+          type: "mrkdwn",
+          text: `*Error Name*: ${this.name}`,
+        },
+        {
+          type: "mrkdwn",
+          text: `*From Account*: ${this.config.getSenderPk()}`,
+        },
+        {
+          type: "mrkdwn",
+          text: `*Message*: ${this.message}`,
+        },
+      ],
+    };
+
+    return {
+      blocks: [...context, errorBlock],
+    };
+  }
+}
+
 export class DispatchError extends FaucetError {
   section: string;
   method: string;

--- a/src/slack_service/slack.ts
+++ b/src/slack_service/slack.ts
@@ -30,7 +30,7 @@ export class SlackNotifier {
     const errorKey = error.constructor.name;
     const lastHandled = this.errorTimestamps.get(errorKey) || 0;
     const timeSinceLastHandled = now - lastHandled;
-
+    
     //8 hour waiting time
     if (
       timeSinceLastHandled >=

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,40 +1,16 @@
 {
   "compilerOptions": {
-    "pretty": true,
-    "target": "es2020" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
-    "module": "NodeNext" /* Specify what module code is generated. */,
-    "rootDir": "./src" /* Specify the root folder within your source files. */,
-    "moduleResolution": "NodeNext",
-    "sourceMap": true /* Specify how TypeScript looks up a file from a given module specifier. */,
-    "outDir": "./dist" /* Specify an output folder for all emitted files. */,
-    "removeComments": true /* Disable emitting comments. */,
-    /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    "importsNotUsedAsValues": "remove" /* Specify emit/checking behavior for imports that are only used for types. */,
-    "isolatedModules": true /* Ensure that each file can be safely transpiled without relying on other imports. */,
-    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true /* Enable all strict type-checking options. */,
-    "noImplicitAny": true /* Enable error reporting for expressions and declarations with an implied 'any' type. */,
-    "strictNullChecks": true /* When type checking, take into account 'null' and 'undefined'. */,
-    "strictFunctionTypes": true /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */,
-    "strictBindCallApply": true /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */,
-    "strictPropertyInitialization": true /* Check for class properties that are declared but not set in the constructor. */,
-    "noImplicitThis": true /* Enable error reporting when 'this' is given the type 'any'. */,
-    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
-    "alwaysStrict": true /* Ensure 'use strict' is always emitted. */,
-    "noUnusedLocals": false /* Enable error reporting when local variables aren't read. */,
-    "noUnusedParameters": false /* Raise an error when a function parameter isn't read. */,
-    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
-    "noImplicitReturns": true /* Enable error reporting for codepaths that do not explicitly return in a function. */,
-    "noFallthroughCasesInSwitch": true /* Enable error reporting for fallthrough cases in switch statements. */,
-    /* Skip type checking .d.ts files that are included with TypeScript. */
+    "strict": true,
+    "module": "ESNext", 
+    "target": "ES2020",
+    "moduleResolution": "Node",
     "skipLibCheck": true,
-    "typeRoots": ["./src/@types"] /* Skip type checking all .d.ts files. */
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
   },
-  "exclude": ["node_modules"],
   "ts-node": {
+    "experimentalSpecifierResolution": "node",
+    "transpileOnly": true,
     "esm": true,
-    "experimentalSpecifierResolution": "node"
   }
 }


### PR DESCRIPTION
Closes #3.

Modified `ApiManager` such that a callback with the desired transaction for the Polkadot.js `ApiPromise` is passed to a new method `executeApiCall`. This method will retry reloading the api once when encountering an error corresponding to an invalid signature and attempt to submit the transaction again before returning the error.

This fix is intended for the case in which the cached api object becomes obsolete and invalid, for example after a runtime upgrade, where a simple reload of the `ApiPromise` object fixes the issue.

### Additional modifications
- Other RPC errors will now be sent to slack, although a re-connection and retry will not be attempted.
- Reduces the previously generic `tsconfig.json` template to the minimum required configuration for this project.

